### PR TITLE
MVP化対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:25.4.0'
     compile 'io.realm:android-adapters:2.1.0'
     compile 'com.android.support:design:25.4.0'
+    compile "io.reactivex.rxjava2:rxjava:2.0.1"
 }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/AbstractPersonRealmHelper.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/AbstractPersonRealmHelper.java
@@ -29,6 +29,8 @@ public abstract class AbstractPersonRealmHelper<T extends RealmObject> {
 
     public abstract RealmResults<T> findAll();
 
+    public abstract RealmResults<T> sortedId();
+
     public abstract void delete(int position);
 
     public abstract void setIndex(Person person, int index);

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRealmHelper.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRealmHelper.java
@@ -51,5 +51,10 @@ public class PersonRealmHelper extends AbstractPersonRealmHelper<Person> {
         return mRealm.where(Person.class).findAllSorted("index");
     }
 
+    @Override
+    public RealmResults<Person> sortedId() {
+        return mRealm.where(Person.class).findAllSorted("id");
+    }
+
 
 }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRealmHelper.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRealmHelper.java
@@ -48,7 +48,7 @@ public class PersonRealmHelper extends AbstractPersonRealmHelper<Person> {
 
     @Override
     public RealmResults<Person> findAll() {
-        return mRealm.where(Person.class).findAll();
+        return mRealm.where(Person.class).findAllSorted("index");
     }
 
 

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.util.Printer;
 
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
+import com.pengin.poinsetia.konkatsudiary.View.PersonAdapter;
 
 import io.reactivex.Single;
 import io.realm.RealmList;
@@ -37,6 +38,25 @@ public class PersonRepository implements PersonContract.Model{
             }
     }
 
+    @Override
+    public RealmList<Person> createPerson(int age, String name) {
+        // PrimaryKeyの取得
+        int primaryKey = getLastPrimaryKey();
+        int position = getIndex();
+        RealmResults<Person> results = createList(getPerson(primaryKey, age, name, position));
+        try {
+            mPersonList.clear();
+            mPersonList.addAll(results.subList(0,results.size()));
+            Log.d("mPrimaryKey", primaryKey + "");
+            return mPersonList;
+        } catch (Exception ex) {
+            Log.d(TAG,"onError: " + ex);
+            return null;
+        }
+
+    }
+
+
     /**
      * インデックスの入れ替えを行う
      */
@@ -59,5 +79,61 @@ public class PersonRepository implements PersonContract.Model{
     @Override
     public void itemIndexRenumber() {
 
+    }
+
+    /**
+     * レコード追加用のPrimaryKeyを返す
+     * @return PrimaryKey
+     */
+    private int getLastPrimaryKey() {
+        RealmResults<Person> results = mRealmHelper.findAll();
+        if (results.size() == 0) {
+            return 0;
+        } else {
+            // 最新のPrimaryKey + 1 を返却する
+            results.sort("id");
+            return results.last().getId() + 1;
+        }
+    }
+
+    /**
+     * レコード追加用のIndexを返す
+     * @return Index
+     */
+    private int getIndex() {
+        // コード数がリストのインデックスになる
+        RealmResults<Person> results = mRealmHelper.findAll();
+        return results.size();
+    }
+
+    /**
+     * DB追加用のPersonを生成する
+     * @param id PrimaryKey
+     * @param age 年齢
+     * @param name 名前
+     * @param index リストの初期位置
+     * @return Person
+     */
+    private Person getPerson(int id, int age, String name, int index) {
+
+        Person person = new Person();
+        person.setId(id);
+        person.setAge(age);
+        person.setName(name);
+        person.setIndex(index);
+
+        return person;
+    }
+
+    // レコードの追加を実行
+    private RealmResults<Person> createList(Person person) {
+        // insert
+        PersonRealmHelper.insertOneShot(person);
+        // where
+        RealmResults<Person> results = mRealmHelper.findAll();
+        // positionでソート
+        results = results.sort("index");
+
+        return results;
     }
 }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -65,8 +65,15 @@ public class PersonRepository implements PersonContract.Model{
      * インデックスの入れ替えを行う
      */
     @Override
-    public void itemIndexReplace() {
+    public void itemIndexReplace(int fromIndex, int toIndex) {
+        Person fromPerson = mRealmHelper.getRealmObject(fromIndex);
+        Person toPerson = mRealmHelper.getRealmObject(toIndex);
+        mRealmHelper.setIndex(fromPerson, toIndex);
+        mRealmHelper.setIndex(toPerson, fromIndex);
 
+        mPersonList.clear();
+        RealmResults<Person> results = mRealmHelper.findAll();
+        mPersonList.addAll(results.subList(0,results.size()));
     }
 
     /**
@@ -98,12 +105,11 @@ public class PersonRepository implements PersonContract.Model{
      * @return PrimaryKey
      */
     private int getLastPrimaryKey() {
-        RealmResults<Person> results = mRealmHelper.findAll();
+        RealmResults<Person> results = mRealmHelper.sortedId();
         if (results.size() == 0) {
             return 0;
         } else {
             // 最新のPrimaryKey + 1 を返却する
-            results.sort("id");
             return results.last().getId() + 1;
         }
     }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -93,11 +93,11 @@ public class PersonRepository implements PersonContract.Model{
     }
 
     /**
-     * アイテムインデックスの振り直しを行う
+     * Realmのクローズ処理を行う
      */
     @Override
-    public void itemIndexRenumber() {
-
+    public void realmClose() {
+        mRealmHelper.destroy();
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -1,16 +1,39 @@
 package com.pengin.poinsetia.konkatsudiary.Model;
 
 
+import android.util.Log;
+
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 
+import io.reactivex.Single;
+import io.reactivex.SingleOnSubscribe;
+import io.realm.RealmResults;
+
 public class PersonRepository implements PersonContract.Model{
+
+    private final String TAG = "PersonRepository";
+    private PersonRealmHelper mRealmHelper;
+
+    public PersonRepository(PersonRealmHelper realmHelper) {
+        this.mRealmHelper = realmHelper;
+    }
 
     /**
      * リストの初期表示のリストデータ取得
      */
     @Override
-    public void getFirstList() {
+    public Single getFirstList() {
 
+        return Single.create((SingleOnSubscribe<RealmResults<Person>>) emitter -> {
+            try {
+                RealmResults<Person> results = mRealmHelper.findAll();
+                emitter.onSuccess(results);
+                Log.d(TAG,"onSuccess");
+            } catch (Exception ex) {
+                emitter.onError(ex);
+                Log.d(TAG,"onError");
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -1,0 +1,39 @@
+package com.pengin.poinsetia.konkatsudiary.Model;
+
+
+import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
+
+public class PersonRepository implements PersonContract.Model{
+
+    /**
+     * リストの初期表示のリストデータ取得
+     */
+    @Override
+    public void getFirstList() {
+
+    }
+
+    /**
+     * インデックスの入れ替えを行う
+     */
+    @Override
+    public void itemIndexReplace() {
+
+    }
+
+    /**
+     * アイテムの削除を行う
+     */
+    @Override
+    public void itemDelete() {
+
+    }
+
+    /**
+     * アイテムインデックスの振り直しを行う
+     */
+    @Override
+    public void itemIndexRenumber() {
+
+    }
+}

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -2,38 +2,39 @@ package com.pengin.poinsetia.konkatsudiary.Model;
 
 
 import android.util.Log;
+import android.util.Printer;
 
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 
 import io.reactivex.Single;
-import io.reactivex.SingleOnSubscribe;
+import io.realm.RealmList;
 import io.realm.RealmResults;
 
 public class PersonRepository implements PersonContract.Model{
 
     private final String TAG = "PersonRepository";
     private PersonRealmHelper mRealmHelper;
+    private RealmList<Person> mPersonList;
 
-    public PersonRepository(PersonRealmHelper realmHelper) {
-        this.mRealmHelper = realmHelper;
+    public PersonRepository() {
+        mRealmHelper = new PersonRealmHelper();
+        mPersonList = new RealmList<>();
     }
 
     /**
      * リストの初期表示のリストデータ取得
      */
     @Override
-    public Single getFirstList() {
-
-        return Single.create((SingleOnSubscribe<RealmResults<Person>>) emitter -> {
+    public RealmList<Person> getFirstList() {
             try {
                 RealmResults<Person> results = mRealmHelper.findAll();
-                emitter.onSuccess(results);
+                mPersonList.addAll(results.subList(0,results.size()));
                 Log.d(TAG,"onSuccess");
+                return mPersonList;
             } catch (Exception ex) {
-                emitter.onError(ex);
-                Log.d(TAG,"onError");
+                Log.d(TAG,"onError: " + ex);
+                return null;
             }
-        });
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Model/PersonRepository.java
@@ -73,11 +73,16 @@ public class PersonRepository implements PersonContract.Model{
      * アイテムの削除を行う
      */
     @Override
-    public int itemDelete(int index) {
+    public RealmList<Person> itemDelete(int index) {
         mRealmHelper.delete(index);
         // 削除後 index を振り直す
-        //
-        return setUnderList(index);
+        if (setUnderList(index) != ERROR_INDEX) {
+            mPersonList.clear();
+            RealmResults<Person> results = mRealmHelper.findAll();
+            mPersonList.addAll(results.subList(0,results.size()));
+            return mPersonList;
+        }
+        return null;
     }
 
     /**
@@ -163,12 +168,12 @@ public class PersonRepository implements PersonContract.Model{
                     mRealmHelper.setIndex(person, newPos);
                     newPos++;
                 }
-//                persons.clear();
-                return index;
+                persons.clear();
             }
-            // 削除後のリストサイズが0の時は-1を返す
-            return ERROR_INDEX;
+            // 削除したインデックスを返却する
+            return index;
         } catch (Exception ex) {
+            Log.d(TAG,"onError: " + ex);
             return ERROR_INDEX;
         }
     }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -19,7 +19,7 @@ public interface PersonContract {
         void dialogResultOk(int age, String name);
 
         // リストの入れ替えイベント
-        void onMoveList();
+        void onMoveList(int fromIndex, int toIndex);
 
         // リストのスワイプ削除イベント
         void onSwiped(int index);
@@ -48,7 +48,7 @@ public interface PersonContract {
         RealmList<Person> createPerson(int age, String name);
 
         // インデックスの入れ替えを行う
-        void itemIndexReplace();
+        void itemIndexReplace(int fromIndex, int toIndex);
 
         // アイテムの削除を行う
         RealmList<Person> itemDelete(int index);

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -1,0 +1,37 @@
+package com.pengin.poinsetia.konkatsudiary.Presenter;
+
+public interface PersonContract {
+
+    interface Presenter {
+        // リストの初期表示イベント
+        void initList();
+        // FABの押下イベント
+        void pressFAB();
+        // リストの入れ替えイベント
+        void onMoveList();
+        // リストのスワイプ削除イベント
+        void onSwiped();
+    }
+
+    interface View {
+        // ダイアログの生成を行う
+        void showDialog();
+        // リストの表示を行う
+        void showList();
+        // Adapterに入れ替え後の通知を行う
+        void notifyItemMoved();
+
+    }
+
+    interface Model {
+        // リストの初期表示のリストデータ取得
+        void getFirstList();
+        // インデックスの入れ替えを行う
+        void itemIndexReplace();
+        // アイテムの削除を行う
+        void itemDelete();
+        // アイテムインデックスの振り直しを行う
+        void itemIndexRenumber();
+    }
+
+}

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -23,6 +23,9 @@ public interface PersonContract {
 
         // リストのスワイプ削除イベント
         void onSwiped(int index);
+
+        // 終了処理イベント
+        void onDestroy();
     }
 
     interface View {
@@ -53,8 +56,9 @@ public interface PersonContract {
         // アイテムの削除を行う
         RealmList<Person> itemDelete(int index);
 
-        // アイテムインデックスの振り直しを行う
-        void itemIndexRenumber();
+        // DBのクローズ処理を行う
+        void realmClose();
+
     }
 
     int ERROR_INDEX = -1;

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -33,7 +33,7 @@ public interface PersonContract {
         void showList(RealmList<Person> results);
 
         // Adapterに削除後の通知を行う
-        void notifyItemRemoved(int newIndex);
+        void notifyItemRemoved();
 
         // Adapterに入れ替え後の通知を行う
         void notifyItemMoved();
@@ -51,7 +51,7 @@ public interface PersonContract {
         void itemIndexReplace();
 
         // アイテムの削除を行う
-        int itemDelete(int index);
+        RealmList<Person> itemDelete(int index);
 
         // アイテムインデックスの振り直しを行う
         void itemIndexRenumber();

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -15,6 +15,9 @@ public interface PersonContract {
         // FABの押下イベント
         void pressFAB();
 
+        // Dialog「閉じるボタン」押下
+        void dialogResultOk(int age, String name);
+
         // リストの入れ替えイベント
         void onMoveList();
 
@@ -37,6 +40,9 @@ public interface PersonContract {
     interface Model {
         // リストの初期表示のリストデータ取得
         RealmList<Person> getFirstList();
+
+        // 新しいPersonアイテムの生成
+        RealmList<Person> createPerson(int age, String name);
 
         // インデックスの入れ替えを行う
         void itemIndexReplace();

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -1,14 +1,22 @@
 package com.pengin.poinsetia.konkatsudiary.Presenter;
 
+import com.pengin.poinsetia.konkatsudiary.Model.Person;
+
+import io.reactivex.Single;
+import io.realm.RealmResults;
+
 public interface PersonContract {
 
     interface Presenter {
         // リストの初期表示イベント
         void initList();
+
         // FABの押下イベント
         void pressFAB();
+
         // リストの入れ替えイベント
         void onMoveList();
+
         // リストのスワイプ削除イベント
         void onSwiped();
     }
@@ -16,8 +24,10 @@ public interface PersonContract {
     interface View {
         // ダイアログの生成を行う
         void showDialog();
+
         // リストの表示を行う
-        void showList();
+        void showList(RealmResults<Person> results);
+
         // Adapterに入れ替え後の通知を行う
         void notifyItemMoved();
 
@@ -25,11 +35,14 @@ public interface PersonContract {
 
     interface Model {
         // リストの初期表示のリストデータ取得
-        void getFirstList();
+        Single getFirstList();
+
         // インデックスの入れ替えを行う
         void itemIndexReplace();
+
         // アイテムの削除を行う
         void itemDelete();
+
         // アイテムインデックスの振り直しを行う
         void itemIndexRenumber();
     }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -22,7 +22,7 @@ public interface PersonContract {
         void onMoveList();
 
         // リストのスワイプ削除イベント
-        void onSwiped();
+        void onSwiped(int index);
     }
 
     interface View {
@@ -31,6 +31,9 @@ public interface PersonContract {
 
         // リストの表示を行う
         void showList(RealmList<Person> results);
+
+        // Adapterに削除後の通知を行う
+        void notifyItemRemoved(int newIndex);
 
         // Adapterに入れ替え後の通知を行う
         void notifyItemMoved();
@@ -48,10 +51,12 @@ public interface PersonContract {
         void itemIndexReplace();
 
         // アイテムの削除を行う
-        void itemDelete();
+        int itemDelete(int index);
 
         // アイテムインデックスの振り直しを行う
         void itemIndexRenumber();
     }
+
+    int ERROR_INDEX = -1;
 
 }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonContract.java
@@ -3,6 +3,7 @@ package com.pengin.poinsetia.konkatsudiary.Presenter;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
 
 import io.reactivex.Single;
+import io.realm.RealmList;
 import io.realm.RealmResults;
 
 public interface PersonContract {
@@ -26,7 +27,7 @@ public interface PersonContract {
         void showDialog();
 
         // リストの表示を行う
-        void showList(RealmResults<Person> results);
+        void showList(RealmList<Person> results);
 
         // Adapterに入れ替え後の通知を行う
         void notifyItemMoved();
@@ -35,7 +36,7 @@ public interface PersonContract {
 
     interface Model {
         // リストの初期表示のリストデータ取得
-        Single getFirstList();
+        RealmList<Person> getFirstList();
 
         // インデックスの入れ替えを行う
         void itemIndexReplace();

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -44,8 +44,16 @@ public class PersonPresenter implements PersonContract.Presenter {
      */
     @Override
     public void pressFAB() {
-
+        mView.showDialog();
     }
+
+    @Override
+    public void dialogResultOk(int age, String name) {
+        RealmList<Person> personList = mRepository.createPerson(age, name);
+        // 1件以上あるならViewに表示要求
+        if (personList.size() != 0) mView.showList(personList);
+    }
+
 
     /**
      * リストの入れ替えイベント

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -1,13 +1,49 @@
 package com.pengin.poinsetia.konkatsudiary.Presenter;
 
 
+import android.util.Log;
+
+import com.pengin.poinsetia.konkatsudiary.Model.Person;
+import com.pengin.poinsetia.konkatsudiary.Model.PersonRepository;
+
+import io.reactivex.observers.DisposableSingleObserver;
+import io.reactivex.schedulers.Schedulers;
+import io.realm.RealmResults;
+
 public class PersonPresenter implements PersonContract.Presenter {
+
+    private final String TAG = "PersonPresenter";
+
+    private PersonContract.View mView;
+    private PersonRepository mRepository;
+
+    public PersonPresenter(PersonContract.View view, PersonRepository repository) {
+        this.mView = view;
+        this.mRepository = repository;
+    }
+
     /**
      * リストの初期表示イベント
      */
     @Override
     public void initList() {
-
+        mRepository.getFirstList()
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.single())
+                .subscribe(new DisposableSingleObserver<RealmResults<Person>> () {
+                    @Override
+                    public void onSuccess(RealmResults<Person> results) {
+                        Log.d(TAG,"onSuccess");
+                        if (results.size() != 0) {
+                            mView.showList(results);
+                        }
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        Log.d(TAG,"onError");
+                        // error
+                    }
+                });
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -6,8 +6,14 @@ import android.util.Log;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
 import com.pengin.poinsetia.konkatsudiary.Model.PersonRepository;
 
+import io.reactivex.Observer;
+import io.reactivex.Single;
+import io.reactivex.SingleEmitter;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleOnSubscribe;
 import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
+import io.realm.RealmList;
 import io.realm.RealmResults;
 
 public class PersonPresenter implements PersonContract.Presenter {
@@ -17,9 +23,9 @@ public class PersonPresenter implements PersonContract.Presenter {
     private PersonContract.View mView;
     private PersonRepository mRepository;
 
-    public PersonPresenter(PersonContract.View view, PersonRepository repository) {
+    public PersonPresenter(PersonContract.View view) {
         this.mView = view;
-        this.mRepository = repository;
+        mRepository = new PersonRepository();
     }
 
     /**
@@ -27,23 +33,8 @@ public class PersonPresenter implements PersonContract.Presenter {
      */
     @Override
     public void initList() {
-        mRepository.getFirstList()
-                .subscribeOn(Schedulers.io())
-                .observeOn(Schedulers.single())
-                .subscribe(new DisposableSingleObserver<RealmResults<Person>> () {
-                    @Override
-                    public void onSuccess(RealmResults<Person> results) {
-                        Log.d(TAG,"onSuccess");
-                        if (results.size() != 0) {
-                            mView.showList(results);
-                        }
-                    }
-                    @Override
-                    public void onError(Throwable e) {
-                        Log.d(TAG,"onError");
-                        // error
-                    }
-                });
+        RealmList<Person> personList = mRepository.getFirstList();
+        if (personList.size() != 0) mView.showList(personList);
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -16,6 +16,8 @@ import io.reactivex.schedulers.Schedulers;
 import io.realm.RealmList;
 import io.realm.RealmResults;
 
+import static com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract.ERROR_INDEX;
+
 public class PersonPresenter implements PersonContract.Presenter {
 
     private final String TAG = "PersonPresenter";
@@ -67,8 +69,12 @@ public class PersonPresenter implements PersonContract.Presenter {
      * リストのスワイプ削除イベント
      */
     @Override
-    public void onSwiped() {
-
+    public void onSwiped(int index) {
+        int newIndex = mRepository.itemDelete(index);
+        // エラーインデックスでなければViewに通知する
+        if (newIndex != ERROR_INDEX) {
+            mView.notifyItemRemoved(newIndex);
+        }
     }
 
 

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -61,8 +61,9 @@ public class PersonPresenter implements PersonContract.Presenter {
      * リストの入れ替えイベント
      */
     @Override
-    public void onMoveList() {
-
+    public void onMoveList(int fromIndex, int toIndex) {
+        mRepository.itemIndexReplace(fromIndex,toIndex);
+        mView.notifyItemMoved();
     }
 
     /**

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -76,5 +76,13 @@ public class PersonPresenter implements PersonContract.Presenter {
         if (personList != null ) mView.notifyItemRemoved();
     }
 
+    /**
+     * 終了処理イベント
+     */
+    @Override
+    public void onDestroy() {
+        mRepository.realmClose();
+    }
+
 
 }

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -1,0 +1,38 @@
+package com.pengin.poinsetia.konkatsudiary.Presenter;
+
+
+public class PersonPresenter implements PersonContract.Presenter {
+    /**
+     * リストの初期表示イベント
+     */
+    @Override
+    public void initList() {
+
+    }
+
+    /**
+     * FABの押下イベント
+     */
+    @Override
+    public void pressFAB() {
+
+    }
+
+    /**
+     * リストの入れ替えイベント
+     */
+    @Override
+    public void onMoveList() {
+
+    }
+
+    /**
+     * リストのスワイプ削除イベント
+     */
+    @Override
+    public void onSwiped() {
+
+    }
+
+
+}

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -70,11 +70,9 @@ public class PersonPresenter implements PersonContract.Presenter {
      */
     @Override
     public void onSwiped(int index) {
-        int newIndex = mRepository.itemDelete(index);
-        // エラーインデックスでなければViewに通知する
-        if (newIndex != ERROR_INDEX) {
-            mView.notifyItemRemoved(newIndex);
-        }
+        RealmList<Person> personList = mRepository.itemDelete(index);
+        // リストが返却されればViewに通知する
+        if (personList != null ) mView.notifyItemRemoved();
     }
 
 

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/Presenter/PersonPresenter.java
@@ -33,7 +33,9 @@ public class PersonPresenter implements PersonContract.Presenter {
      */
     @Override
     public void initList() {
+        // Repositoryに初期のリスト取得要求
         RealmList<Person> personList = mRepository.getFirstList();
+        // 1件以上あるならViewに表示要求
         if (personList.size() != 0) mView.showList(personList);
     }
 

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/AddPersonDialogFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/AddPersonDialogFragment.java
@@ -1,0 +1,57 @@
+package com.pengin.poinsetia.konkatsudiary.View;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.support.v4.app.DialogFragment;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.pengin.poinsetia.konkatsudiary.R;
+
+public class AddPersonDialogFragment extends DialogFragment{
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.MyAlertDialogStyle);
+        LayoutInflater inflater = (LayoutInflater)getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View view = inflater.inflate(R.layout.flower_dialog_layout, null);
+        Intent result = new Intent();
+        // 年齢選択用プルダウンリスト
+        Spinner selectedAge = (Spinner) view.findViewById(R.id.person_age_spinner);
+        selectedAge.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                if (position != 0) {
+                    String age = parent.getItemAtPosition(position).toString();
+                    result.putExtra("age", Integer.parseInt(age));
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // do Nothing
+            }
+        });
+        builder.setView(view);
+        builder.setNegativeButton("閉じる", (dialog, id) -> {
+
+            TextView nameEditText = (TextView)view.findViewById(R.id.person_name_text);
+            String nameText = nameEditText.getText().toString();
+            result.putExtra("name",nameText);
+            if (getTargetFragment() != null) {
+                getTargetFragment().onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, result);
+            }
+        });
+        return builder.create();
+    }
+
+}

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -2,16 +2,12 @@ package com.pengin.poinsetia.konkatsudiary.View;
 
 
 import android.app.Activity;
-import android.app.Dialog;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -20,21 +16,15 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.Spinner;
-import android.widget.TextView;
 
-import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
+import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonPresenter;
 import com.pengin.poinsetia.konkatsudiary.R;
 
-import java.util.ArrayList;
-
 import io.realm.Realm;
 import io.realm.RealmList;
-import io.realm.RealmResults;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -75,6 +65,15 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         mRecyclerView.setAdapter(mAdapter);
         Log.d(TAG,"showList");
     }
+
+    /**
+     * Adapterに削除後の通知を行う
+     */
+    @Override
+    public void notifyItemRemoved(int index) {
+        mAdapter.notifyItemRemoved(index);
+    }
+
 
     /**
      * Adapterに入れ替え後の通知を行う
@@ -165,11 +164,9 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
                     @Override
                     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
                         int index = viewHolder.getAdapterPosition();
-                        // ★リストのスワイプ削除イベント・Presenter
-                        // ★アイテムの削除を行う・Model
-                        deleteList(index);
-                        mAdapter.notifyItemRemoved(index);
-
+                        // リストのスワイプ削除イベント
+                        mPresenter.onSwiped(index);
+//                        mAdapter.notifyItemRemoved(index);
                     }
                 });
         mIth.attachToRecyclerView(mRecyclerView);
@@ -207,38 +204,6 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     }
 
     // ~~~~~~ Repository に移動予定 ~~~~~~
-
-    /**
-     * レコードの削除を実行
-     */
-    private void deleteList(int index) {
-        mRealmHelper.delete(index);
-        // ★削除後 index の 振り直し・Model
-        setUnderList(index);
-    }
-
-    /**
-     * 指定位置より下のIndexを振り直す
-     * @param index 振り直し始め番号
-     */
-    private  void setUnderList(int index) {
-        // 削除した以下の位置のリストを取得
-        RealmResults<Person> results = mRealmHelper.deleteUnderList(index);
-        if (results.size() != 0) {
-            int newPos = index;
-            // 一度Arrayに詰める
-            ArrayList<Person> persons = new ArrayList<>();
-            for (int i = 0; i < results.size();i++ ) {
-                persons.add(results.get(i));
-            }
-            // Arrayの情報を元に振り直しを実行する
-            for (Person person : persons) {
-                mRealmHelper.setIndex(person,newPos);
-                newPos++;
-            }
-            persons.clear();
-        }
-    }
 
     /**
      * Indexの入れ替えを実行する

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -21,7 +21,6 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
-import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonPresenter;
 import com.pengin.poinsetia.konkatsudiary.R;
@@ -43,12 +42,10 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     private final static int MSG_MOVE_LIST = 2;
 
     private Activity mActivity = null;
-    private View mView;
 
     // RecyclerViewとAdapter
     private RecyclerView mRecyclerView = null;
     private PersonAdapter mAdapter = null;
-    private PersonRealmHelper mRealmHelper;
     private Handler mHandler;
 
     private PersonPresenter mPresenter;
@@ -109,16 +106,16 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mView = inflater.inflate(R.layout.fragment_main, container, false);
+        View view = inflater.inflate(R.layout.fragment_main, container, false);
         // RecyclerViewの参照を取得
-        mRecyclerView = (RecyclerView) mView.findViewById(R.id.recycler_view);
+        mRecyclerView = (RecyclerView) view.findViewById(R.id.recycler_view);
         // レイアウトマネージャを設定(ここで縦方向の標準リストであることを指定)
         mRecyclerView.setLayoutManager(new LinearLayoutManager(mActivity));
         // フローティングアクションボタンの実装
-        FloatingActionButton fab = (FloatingActionButton) mView.findViewById(R.id.fab);
+        FloatingActionButton fab = (FloatingActionButton) view.findViewById(R.id.fab);
         fab.setOnClickListener(this);
 
-        return mView;
+        return view;
     }
 
     @Override
@@ -145,7 +142,6 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         mRecyclerView.addItemDecoration(dividerItemDecoration);
 
         Realm.init(mActivity);
-//        mRealmHelper = new PersonRealmHelper();
         mPresenter = new PersonPresenter(this);
 
         // メインHandlerの作成
@@ -227,7 +223,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         super.onDestroy();
         mRecyclerView.setAdapter(null);
         // DB クローズ
-        mRealmHelper.destroy();
+        mPresenter.onDestroy();
         // ハンドラーの停止
         if (mHandler != null) {
             mHandler = null;

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -27,7 +27,9 @@ import android.widget.TextView;
 
 import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
+import com.pengin.poinsetia.konkatsudiary.Model.PersonRepository;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
+import com.pengin.poinsetia.konkatsudiary.Presenter.PersonPresenter;
 import com.pengin.poinsetia.konkatsudiary.R;
 
 import java.util.ArrayList;
@@ -41,6 +43,8 @@ import io.realm.RealmResults;
 public class PersonFragment extends Fragment implements OnRecyclerListener,View.OnClickListener,
         PersonContract.View{
 
+    private final String TAG = "PersonFragment";
+
     private final int DIALOG_KEY = 100;
 
     private Activity mActivity = null;
@@ -51,20 +55,24 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     private PersonAdapter mAdapter = null;
     private PersonRealmHelper mRealmHelper;
 
+    private PersonPresenter mPresenter;
+    private PersonRepository mRepository;
+
     /**
      * ダイアログの生成を行う
      */
     @Override
     public void showDialog() {
-
     }
 
     /**
      * リストの表示を行う
      */
     @Override
-    public void showList() {
-
+    public void showList(RealmResults<Person> results) {
+        mAdapter = new PersonAdapter(mActivity, results, this);
+        mRecyclerView.setAdapter(mAdapter);
+        Log.d(TAG,"showList");
     }
 
     /**
@@ -131,7 +139,14 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         mRecyclerView.addItemDecoration(dividerItemDecoration);
 
         Realm.init(mActivity);
+        mRealmHelper = new PersonRealmHelper();
+
+        mRepository = new PersonRepository(mRealmHelper);
+        mPresenter = new PersonPresenter(this, mRepository);
+
         // ★リスト初期表示イベント・Presenter
+        mPresenter.initList();
+        /*
         // Helperの作成
         // ★リストの初期表示のDB準備・Model
         mRealmHelper = new PersonRealmHelper();
@@ -146,6 +161,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
             mRecyclerView.setAdapter(mAdapter);
 
         }
+        */
 
         ItemTouchHelper mIth  = new ItemTouchHelper(
                 new ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP | ItemTouchHelper.DOWN, ItemTouchHelper.LEFT) {

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 
 import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
+import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 import com.pengin.poinsetia.konkatsudiary.R;
 
 import java.util.ArrayList;
@@ -37,7 +38,8 @@ import io.realm.RealmResults;
 /**
  * A simple {@link Fragment} subclass.
  */
-public class PersonFragment extends Fragment implements OnRecyclerListener,View.OnClickListener{
+public class PersonFragment extends Fragment implements OnRecyclerListener,View.OnClickListener,
+        PersonContract.View{
 
     private final int DIALOG_KEY = 100;
 
@@ -48,6 +50,30 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     private RecyclerView mRecyclerView = null;
     private PersonAdapter mAdapter = null;
     private PersonRealmHelper mRealmHelper;
+
+    /**
+     * ダイアログの生成を行う
+     */
+    @Override
+    public void showDialog() {
+
+    }
+
+    /**
+     * リストの表示を行う
+     */
+    @Override
+    public void showList() {
+
+    }
+
+    /**
+     * Adapterに入れ替え後の通知を行う
+     */
+    @Override
+    public void notifyItemMoved() {
+
+    }
 
     public interface RecyclerFragmentListener {
         void onRecyclerEvent();
@@ -84,7 +110,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
 
         switch (v.getId()) {
             case R.id.fab :
-                // ダイアログフラグメンドの生成
+                // ★FABの押下イベント・Presenter
                 DialogFragment newFragment = new FlowerDialogFragment();
                 newFragment.setTargetFragment(this,DIALOG_KEY);
                 newFragment.show(getFragmentManager(), "person");
@@ -105,8 +131,9 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         mRecyclerView.addItemDecoration(dividerItemDecoration);
 
         Realm.init(mActivity);
+        // ★リスト初期表示イベント・Presenter
         // Helperの作成
-        // リストの初期表示
+        // ★リストの初期表示のDB準備・Model
         mRealmHelper = new PersonRealmHelper();
         // where
         RealmResults<Person> results = mRealmHelper.findAll();
@@ -114,7 +141,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         if (listSize != 0) {
             // positionでソート
             results = results.sort("index");
-            // リスト表示
+            // ★リスト表示・View
             mAdapter = new PersonAdapter(mActivity, results, this);
             mRecyclerView.setAdapter(mAdapter);
 
@@ -130,8 +157,10 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
                         int fromIndex = viewHolder.getAdapterPosition();
                         // 移動後の場所
                         int toIndex = target.getAdapterPosition();
-                        // インデックスの入れ替えを行う
+                        // ★リストの入れ替えイベント・Presenter
+                        // ★インデックスの入れ替えを行う・Model
                         indexReplace(fromIndex,toIndex);
+                        // ★入れ替え後の通知を行う・View
                         mAdapter.notifyItemMoved(fromIndex,toIndex);
                         return true;
                     }
@@ -139,6 +168,8 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
                     @Override
                     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
                         int index = viewHolder.getAdapterPosition();
+                        // ★リストのスワイプ削除イベント・Presenter
+                        // ★アイテムの削除を行う・Model
                         deleteList(index);
                         mAdapter.notifyItemRemoved(index);
 
@@ -155,6 +186,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
                 if (data != null) {
                     int age = data.getIntExtra("age",0);
                     String name = data.getStringExtra("name");
+                    // ★新しいPersonアイテムの生成・Model
                     // PrimaryKeyの取得
                     int primaryKey = getLastPrimaryKey() ;
                     int position = getIndex();
@@ -192,6 +224,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
             RealmResults<Person> results = mRealmHelper.findAll();
             // positionでソート
             results = results.sort("index");
+            // ★リスト表示・View
             // リスト表示
             mAdapter = new PersonAdapter(mActivity, results, this);
             mRecyclerView.setAdapter(mAdapter);
@@ -228,7 +261,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
      */
     private void deleteList(int index) {
         mRealmHelper.delete(index);
-        // 削除後 index の 振り直し
+        // ★削除後 index の 振り直し・Model
         setUnderList(index);
     }
 

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -35,6 +35,7 @@ import com.pengin.poinsetia.konkatsudiary.R;
 import java.util.ArrayList;
 
 import io.realm.Realm;
+import io.realm.RealmList;
 import io.realm.RealmResults;
 
 /**
@@ -56,7 +57,7 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     private PersonRealmHelper mRealmHelper;
 
     private PersonPresenter mPresenter;
-    private PersonRepository mRepository;
+//    private PersonRepository mRepository;
 
     /**
      * ダイアログの生成を行う
@@ -69,8 +70,8 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
      * リストの表示を行う
      */
     @Override
-    public void showList(RealmResults<Person> results) {
-        mAdapter = new PersonAdapter(mActivity, results, this);
+    public void showList(RealmList<Person> personList) {
+        mAdapter = new PersonAdapter(mActivity, personList, this);
         mRecyclerView.setAdapter(mAdapter);
         Log.d(TAG,"showList");
     }
@@ -141,8 +142,8 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         Realm.init(mActivity);
         mRealmHelper = new PersonRealmHelper();
 
-        mRepository = new PersonRepository(mRealmHelper);
-        mPresenter = new PersonPresenter(this, mRepository);
+//        mRepository = new PersonRepository(mRealmHelper);
+        mPresenter = new PersonPresenter(this);
 
         // ★リスト初期表示イベント・Presenter
         mPresenter.initList();

--- a/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
+++ b/app/src/main/java/com/pengin/poinsetia/konkatsudiary/View/PersonFragment.java
@@ -6,7 +6,6 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-//import android.app.Fragment;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.DialogFragment;
@@ -27,7 +26,6 @@ import android.widget.TextView;
 
 import com.pengin.poinsetia.konkatsudiary.Model.PersonRealmHelper;
 import com.pengin.poinsetia.konkatsudiary.Model.Person;
-import com.pengin.poinsetia.konkatsudiary.Model.PersonRepository;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonContract;
 import com.pengin.poinsetia.konkatsudiary.Presenter.PersonPresenter;
 import com.pengin.poinsetia.konkatsudiary.R;
@@ -57,7 +55,6 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
     private PersonRealmHelper mRealmHelper;
 
     private PersonPresenter mPresenter;
-//    private PersonRepository mRepository;
 
     /**
      * ダイアログの生成を行う
@@ -140,29 +137,11 @@ public class PersonFragment extends Fragment implements OnRecyclerListener,View.
         mRecyclerView.addItemDecoration(dividerItemDecoration);
 
         Realm.init(mActivity);
-        mRealmHelper = new PersonRealmHelper();
-
-//        mRepository = new PersonRepository(mRealmHelper);
+//        mRealmHelper = new PersonRealmHelper();
         mPresenter = new PersonPresenter(this);
 
-        // ★リスト初期表示イベント・Presenter
+        // リスト初期表示イベント
         mPresenter.initList();
-        /*
-        // Helperの作成
-        // ★リストの初期表示のDB準備・Model
-        mRealmHelper = new PersonRealmHelper();
-        // where
-        RealmResults<Person> results = mRealmHelper.findAll();
-        int listSize = results.size();
-        if (listSize != 0) {
-            // positionでソート
-            results = results.sort("index");
-            // ★リスト表示・View
-            mAdapter = new PersonAdapter(mActivity, results, this);
-            mRecyclerView.setAdapter(mAdapter);
-
-        }
-        */
 
         ItemTouchHelper mIth  = new ItemTouchHelper(
                 new ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP | ItemTouchHelper.DOWN, ItemTouchHelper.LEFT) {


### PR DESCRIPTION
-  Issues https://github.com/poin-settia/Diary/issues/7
より、Fragmentで実装していたDB処理をRepositoryに移管し、イベント処理の振り分けはPresenterが指揮るように修正を行った。

MVP化の工程は下記の記事を参考
[日記アプリのMVP化工程記録・1](https://qiita.com/poin-settia/items/4fd1b864fec8b6365acf)
[日記アプリのMVP化工程記録・2](https://qiita.com/poin-settia/items/be18d0ca677efd57c3c7#_reference-b2e1c7b8b85db16c7882)
[日記アプリのMVP化工程記録・3](https://qiita.com/poin-settia/items/c9e5cd2df5648b41b43c)
[日記アプリのMVP化工程記録・4](https://qiita.com/poin-settia/items/ee38c9f557a1f36a350e#_reference-6343565be9be1dbdab68)
[日記アプリのMVP化工程記録・5](https://qiita.com/poin-settia/items/f2404780e8f23d5c36ad#_reference-ca9a75acd1a5c0af6091)
[日記アプリのMVP化工程記録・6](https://qiita.com/poin-settia/items/9c55046b4b9826ef8568)